### PR TITLE
#32-past-event-ribbon

### DIFF
--- a/priv/lib-src/scss/src/blocks/list.scss
+++ b/priv/lib-src/scss/src/blocks/list.scss
@@ -256,6 +256,25 @@
     }
 }
 
+/* the new ribbon for past events */
+.event-status__past {
+  position: absolute;
+  top: 74px;
+  right: -26px;
+  width: 140px;
+  padding: 6px 0;
+  background-color: #197c87;
+  color: white;
+  text-align: center;
+  font-weight: bold;
+  font-size: 1rem;
+  transform: rotate(45deg);
+  transform-origin: top right;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 1;
+  pointer-events: none;
+}
+
 .list-item-kg__content--og {
     .list-item-kg__content__title {
         @extend .list-item-kg__content;

--- a/priv/templates/list/list-item-kg.event.tpl
+++ b/priv/templates/list/list-item-kg.event.tpl
@@ -1,8 +1,11 @@
 
 {% if not (exclude and id.id|member:exclude) %}
 	{% with id.o.hasbanner[1]|default:id.depiction.id|default:m.rsc.fallback.id as dep %}
-	<li class="list-item-kg--event" style="background-image: url('{% image_url dep mediaclass='list-image' crop=dep.crop_center %}');">
+	<li class="list-item-kg--event" style="background-image: url('{% image_url dep mediaclass='list-image' crop=dep.crop_center %}'); position: relative; overflow: hidden;">
 		<a href="{{ id.page_url }}">
+			{% if id.date_start < now %}
+				<div class="event-status__past">Geweest</div>
+			{% endif %}
 			<div class="list-item-kg-event__content">
 				{% include "category-of/category-of.tpl" nolink="true" %}
 


### PR DESCRIPTION
Adds a ribbon with the text 'Geweest' to past events.
Example: 
 ![2025-05-19-145957_hyprshot](https://github.com/user-attachments/assets/f6b6dc9c-5379-47c4-980c-7f12e8e9e532)

This comes with a disclaimer regarding testing: I've tested this on Chrome, Safari & Firefox desktop only.

For testing on mobile i need advice on how to set that up with zotonic. Zotonic expects i add an entry in /etc/hosts, and has the self-signed certificate. How do you deal with that on iPad for example?
