### PR TITLE
Added left padding in page-body to 'ul' and 'ol'

### DIFF
--- a/priv/lib-src/scss/src/layout/content.scss
+++ b/priv/lib-src/scss/src/layout/content.scss
@@ -310,6 +310,10 @@ main {
         }
     }
 
+    ul, ol {
+        padding-left: 1.5em;
+    }
+
     @include mq(min-width, $mediumBreakpoint) {
         margin-bottom: 40px;
     }


### PR DESCRIPTION
Padding was recently added, only to 'ul', to prevent list markup to disappear.
Also added this to 'ol' as this had the same issue

issue #33 

@pasqu4le can you please review and merge if correct?