### PR TITLE
#51 replaced twitter-x with mastodon share button

### DIFF
--- a/priv/lib-src/js/mastodon-share.js
+++ b/priv/lib-src/js/mastodon-share.js
@@ -1,0 +1,22 @@
+// Generate a share link for the user's Mastodon domain 
+function MastodonShare(e){
+
+    var btn = document.getElementById("mastodon-share-btn");
+    var src = btn.getAttribute("data-src");
+    
+    var domain = prompt("Welk Mastodon domein gebruik je?", "mastodon.social");
+    if (domain == "" || domain == null){
+        return;
+    }
+
+    var url = "https://" + domain + "/share?text=" + src;
+    window.open(url, '_blank');
+}
+
+// Wait for the DOM to be parsed before querying elements
+document.addEventListener("DOMContentLoaded", function() {
+  var btn = document.getElementById("mastodon-share-btn");
+  if (btn) {
+    btn.addEventListener("click", MastodonShare);
+  }
+});

--- a/priv/templates/_html_head.tpl
+++ b/priv/templates/_html_head.tpl
@@ -20,7 +20,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.4.1/jquery.fancybox.min.css" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.4.1/jquery.fancybox.min.js"></script>
 <script src='/lib/js/maplibre-gl.js'></script>
+<script src='/lib/js/mastodon-share.js'></script>
 <link rel='stylesheet' href='https://unpkg.com/maplibre-gl@5.1.0/dist/maplibre-gl.css' />
 <script src='https://unpkg.com/maplibre-gl@5.1.0/dist/maplibre-gl.js'></script>
-
 <link rel="me" href="https://mastodon.social/@KennisCloud" />

--- a/priv/templates/share/share.tpl
+++ b/priv/templates/share/share.tpl
@@ -2,9 +2,11 @@
     <li>
         <a href="http://www.facebook.com/sharer.php?u=http%3A%2F%2F{{ m.site.hostname }}{{ id.page_url|urlencode }}&amp;t={{ id.title|urlencode }}" onclick="return !window.open(this.href, 'Facebook', 'width=600,height=500,toolbar=0,location=0,scrollbars=0,status=0')" title="Facebook" class=""><i class="icon--facebook"></i></a>
     </li>
+
     <li>
-        <a href="https://twitter.com/intent/tweet?text={{ id.title|urlencode  }}%20http%3A%2F%2F{{ m.site.hostname }}{{ id.page_url|urlencode }}&amp;t={{ id.title|urlencode }}" onclick="return !window.open(this.href, 'Twitter', 'width=600,height=300,location=0,toolbar=0,scrollbars=0,status=0')" title="Twitter" class=""><i class="icon--twitter"></i></a>
-    </li>
+        <a id="mastodon-share-btn" data-src="{{id.title|urlencode}}&amp;url={{id.page_url_abs|urlencode}}" title="Mastodon" class=""><i class="icon--mastodon"></i></a>
+    </li> 
+
     <li>
         <a href="https://www.linkedin.com/shareArticle?mini=true&amp;title={{ id.title|urlencode }}&amp;url={{ id.page_url_abs|urlencode }}" onclick="return !window.open(this.href, 'LinkedIn', 'width=600,height=300,location=0,toolbar=0,scrollbars=0,status=0')" title="LinkedIn" class=""><i class="icon--linkedin"></i></a>
     </li>


### PR DESCRIPTION
- vervangt het twitter/x button door een mastodon button (gebruikt witte mastodon svg toegevoegd door Frank in #49)
- prompt de gebruiker voor mastodon domein voor redirect (functie toegevoegd in apart js script)
- wat kleine aanpassingen aan voorbeeldcode in #51, vooral vanwege CSP die geen inline javascript toelaat.