### PR TITLE
#50 close contribution

### DIFF
--- a/priv/lib-src/scss/src/blocks/status-tags.scss
+++ b/priv/lib-src/scss/src/blocks/status-tags.scss
@@ -66,6 +66,16 @@
     }
 }
 
+.kg-intro_status--closed,
+.kg-intro_status--gesloten {
+    border-color: $greenDarker;
+    background-color: rgba($greenDarker, 0.6);
+
+    &::before {
+        background-image: url(/lib/images/closed.svg);
+    }
+}
+
 .c-contribution__lvl {
     background-color: $greenDarker;
     border: none;
@@ -87,4 +97,8 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     z-index: 2;
     pointer-events: none;
+
+    &--closed {
+      background-color: $grey; 
+  }
 }

--- a/priv/lib/images/closed.svg
+++ b/priv/lib/images/closed.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="lock.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.565"
+     inkscape:cx="398.23009"
+     inkscape:cy="404.42478"
+     inkscape:window-width="1060"
+     inkscape:window-height="676"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M7 10.0288C7.47142 10 8.05259 10 8.8 10H15.2C15.9474 10 16.5286 10 17 10.0288M7 10.0288C6.41168 10.0647 5.99429 10.1455 5.63803 10.327C5.07354 10.6146 4.6146 11.0735 4.32698 11.638C4 12.2798 4 13.1198 4 14.8V16.2C4 17.8802 4 18.7202 4.32698 19.362C4.6146 19.9265 5.07354 20.3854 5.63803 20.673C6.27976 21 7.11984 21 8.8 21H15.2C16.8802 21 17.7202 21 18.362 20.673C18.9265 20.3854 19.3854 19.9265 19.673 19.362C20 18.7202 20 17.8802 20 16.2V14.8C20 13.1198 20 12.2798 19.673 11.638C19.3854 11.0735 18.9265 10.6146 18.362 10.327C18.0057 10.1455 17.5883 10.0647 17 10.0288M7 10.0288V8C7 5.23858 9.23858 3 12 3C14.7614 3 17 5.23858 17 8V10.0288"
+     stroke="#000000"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="path1"
+     style="fill:none;stroke:#ffffff" />
+</svg>

--- a/priv/templates/_admin_edit_basics_form.contribution.tpl
+++ b/priv/templates/_admin_edit_basics_form.contribution.tpl
@@ -44,7 +44,28 @@
     {% include "_ginger_edit_content_add_to_timeline.tpl" %}
 
     {% catinclude "_ginger_edit_content_status_label.tpl" id extraClass="col-md-6" %}
-
+  
 </fieldset>
 
+<fieldset>
+    <div id="status-closed-container" style="display: none;">
+       {_ status-close-remark-reminder _} 
+       <!-- TODO embed the elm app -->
+    </div>
+</fieldset>
+    {% javascript %}
+    $(document).ready(function() {
+        const $statusField = $('#status-label');
+        const $closedContainer = $('#status-closed-container');
+
+        function toggleClosedWarning() {
+            const value = $statusField.val()?.toLowerCase();
+            $closedContainer.toggle(value === 'closed');
+        }
+
+        $statusField.on('change', toggleClosedWarning);
+    });
+    {% endjavascript %}    
 {% endwith %}
+
+    

--- a/priv/templates/_ginger_edit_content_status_label.tpl
+++ b/priv/templates/_ginger_edit_content_status_label.tpl
@@ -25,6 +25,7 @@
             <option value="Meetup" {% if id.status_label == "Meetup" %}selected{% endif %}>{_ Meetup _}</option>
             <option value="Insights" {% if id.status_label == "Insights" %}selected{% endif %}>{_ Insights _}</option>
             <option value="Discussion" {% if id.status_label == "Discussion" %}selected{% endif %}>{_ Discussion _}</option>
+            <option value="Closed" {% if id.status_label == "Closed" %}selected{% endif %}>{_ Closed _}</option>
         </select>
     </div>
 </div>

--- a/priv/templates/comments/comments.tpl
+++ b/priv/templates/comments/comments.tpl
@@ -17,9 +17,15 @@
         hash = null
     };
 
+    //ocataco: last flag is passed to indicate this page is closed, and no new remarks are allowed
     var app = Elm.Main.init({
         node: remarksElement,
-        flags: [{{ id }}, now, hash]
+        flags: { 
+                 pageId: {{ id }}, 
+                 now: now, 
+                 remarkId: hash, 
+                 isClosed: {{id.status_label == 'Closed'}}
+                 } 
     });
 
     app.ports.scrollIdIntoView.subscribe(function(domId) {

--- a/priv/templates/list/list-item-kg.tpl
+++ b/priv/templates/list/list-item-kg.tpl
@@ -17,7 +17,11 @@
     {% endif %}
     <a href="{{ ref.page_url }}">
         {% if id.status_label %} 
-            <div class="list-item-kg-contribution__lvl">{{ id.status_label|translate }}</div>
+        	{% if id.status_label == 'Closed' %}
+		    <div class=" list-item-kg-contribution__lvl list-item-kg-contribution__lvl--closed">{{ id.status_label|translate }}</div>
+		{% else %} 
+		    <div class="list-item-kg-contribution__lvl">{{ id.status_label|translate }}</div>
+		{% endif %}
         {% endif %}
         <div {% if dep %}class="list-item-kg-contribution__content"{% endif %}>
             <div class="list-item-kg__top">

--- a/priv/templates/page.contribution.tpl
+++ b/priv/templates/page.contribution.tpl
@@ -14,7 +14,9 @@
     <div class="page-body">
     	{{ id.body|show_media }}
 
-        {% include "library/add-references.tpl" %}
+        {% if id.status_label != "Closed" %}
+            {% include "library/add-references.tpl" %}
+        {% endif %}
     </div>
 {% endblock %}
 

--- a/priv/templates/page.event.tpl
+++ b/priv/templates/page.event.tpl
@@ -73,9 +73,11 @@
                             Registreer of log in om te reageren
                         </a>
                     {% else %}
+                        {% if id.status_label != "Closed" %}
                         <a href="#reacties" class="do_anchor btn--primary -is-anchor">
                             Direct reageren
                         </a>
+                        {% endif %}
                     {% endif %}
                     </div>
 

--- a/priv/translations/nl.po
+++ b/priv/translations/nl.po
@@ -640,7 +640,11 @@ msgstr "Voortgang labels zijn zichtbaar in de kennisgroep"
 
 #: user/sites/kenniscloud/templates/_ginger_edit_content_status_label.tpl:20
 msgid "Status labels are visible on contributions and meetups"
-msgstr "Status labels zijn zichtbaar op bijdragen en meetups"
+msgstr "Status labels zijn zichtbaar op bijdragen en meetups."
+
+#: user/sites/kenniscloud/templates/_admin_edit_basics_form.contribution.tpl
+msgid "status-close-remark-reminder"
+msgstr "Vergeet niet een laatste reactie te geven voor je de bijdrage sluit!"
 
 #: user/sites/kenniscloud/templates/_admin_edit_basics.acl_collaboration_group.tpl:
 msgid "Timeline off"
@@ -733,6 +737,10 @@ msgstr "Inzichten"
 #priv/templates/keywords/status-tags.tpl
 msgid "Discussion"
 msgstr "Discussie"
+
+#priv/templates/keywords/status-tags.tpl
+msgid "Closed"
+msgstr "Gesloten"
 
 #priv/templates/keywords/knowledge-lvl-tags.tpl
 msgid "Question"


### PR DESCRIPTION
Change summary:
- Added new status label ('Closed')
- Added lock icon
- Show 'Gesloten' status in contribution header and and progress ribbon
- added dynamic reminder (inline {% javascript %} tag, in admin.contribution template
- added id.status_label conditionals to hide new remarks and references in templates
- passed extra flag to elm remarks application in order to hide the "new remark" button, had to change the flags from tuple to record in order to fix 3 argument constraint.

Note:
I didn't include the proposed 'inline' comment feature in the admin template, because that would mean either to include the entire elm remarks app at the spot, or create something from scratch. I think the reminder should serve just as well?
