### PR TITLE
Fix: tag selection in search query for acl_collaboration_group

### DIFF
--- a/priv/templates/_js_include.tpl
+++ b/priv/templates/_js_include.tpl
@@ -18,7 +18,7 @@
     "js/global-nav.js"
     "js/search-suggestions.js"
     "bootstrap/js/bootstrap.min.js"
-    "js/jquery.fancybox.js"
+    "js/fancybox.js"
     "js/models/loadmore.js"
     "js/modules/z.forminit.js"
 %}

--- a/priv/templates/main-aside/main-aside.acl_collaboration_group.tpl
+++ b/priv/templates/main-aside/main-aside.acl_collaboration_group.tpl
@@ -11,8 +11,11 @@
 	{% endif %}
 
 
-	{% if m.search.paged[{query is_published content_group=id sort=["-is_featured", "-rsc.publication_start", "id"] cat=['contribution', 'event'] hasobject=q.tag|if:[q.tag,'subject']:"*" id_exclude=upcoming_events|make_list pagelen=6}] as result %}
-
+	{% if m.search.paged[
+		q.tag|if
+			:{query is_published content_group=id sort=["-is_featured", "-rsc.publication_start", "id"] cat=['contribution', 'event'] hasobject=[q.tag,'subject'] id_exclude=upcoming_events|make_list pagelen=6}
+			:{query is_published content_group=id sort=["-is_featured", "-rsc.publication_start", "id"] cat=['contribution', 'event'] id_exclude=upcoming_events|make_list pagelen=6}
+	] as result %}
 		<h3 id="contributions" class="bordered-title">Bijdragen</h3>
 		{% if id.has_keyword_filter %}
 			{% if m.search[{facets is_published content_group=id cat=['contribution', 'event'] id_exclude=upcoming_events|make_list}] as facetted %}


### PR DESCRIPTION
Fixes an issue that I've introduced by mistake in #129 as `hasobject="*"` is not the same as no `hasobject` argument.