### PR TITLE
KCI-146: Fix participant avatar callout on hover

### DIFF
--- a/priv/lib-src/scss/src/blocks/person.scss
+++ b/priv/lib-src/scss/src/blocks/person.scss
@@ -118,6 +118,7 @@
     width: 220px;
     padding: 15px;
     opacity: 1;
+    display: none;
     position: absolute;
     top: 10px;
     left: 20px;
@@ -197,6 +198,7 @@
     .person__content {
         padding: 0;
         opacity: 1;
+        display: block;
         flex-grow: 1;
         position: static;
         color: inherit;

--- a/priv/templates/list/list.tpl
+++ b/priv/templates/list/list.tpl
@@ -33,8 +33,8 @@ as
             {% pager result=result qargs %}
         {% endif %}
 
-        <ul id="{{ list_id }}" class="{{ extra_classes }}">
-            {% include list_items_template result=items list_id=list_id list_item_template=list_template class=class extra_classes=extra_classes exclude=exclude %}
+        <ul id="{{ list_id }}" class="{{ class }}">
+            {% include list_items_template result=items list_id=list_id list_item_template=list_template class=extra_classes exclude=exclude %}
         </ul>
 
         {% if infinite_scroll %}

--- a/priv/templates/list/list.tpl
+++ b/priv/templates/list/list.tpl
@@ -33,7 +33,7 @@ as
             {% pager result=result qargs %}
         {% endif %}
 
-        <ul id="{{ list_id }}" class="{{ class }} {{ extra_classes }}">
+        <ul id="{{ list_id }}" class="{{ extra_classes }}">
             {% include list_items_template result=items list_id=list_id list_item_template=list_template class=class extra_classes=extra_classes exclude=exclude %}
         </ul>
 

--- a/priv/templates/main-aside/main-aside.region.tpl
+++ b/priv/templates/main-aside/main-aside.region.tpl
@@ -27,7 +27,7 @@
         "list/list.tpl"
         items=result
         list_template="list/list-item-person-small.tpl"
-        class="person"
-        extraClasses="home-members__list"
+        class="home-members__list"
+        extraClasses="person"
     %}
 {% endif %}


### PR DESCRIPTION
The earlier fix made the hover callouts on avatars in the person list to always show (all simultaneously, not waiting for a hover ;)). This fixes that, by reinstating the `display: none` on `.person__content` and only `display: block` on authors specifically.

Also fixed an earlier bug that in the region pages, callouts of all of the participants would show at once on hover of a single avatar. Turned out that the class logic in the region aside participant list was reversed (which made the initial fix wrong for other lists, e.g. list of KG cards).

**Beware:** We should check the various lists on the platform to see if everything looks good now.