### PR TITLE
KCI-169: Fix contribution (and event) link inclusion for non og links and background info links in frontend edit

### DIFF
--- a/priv/lib-src/elm/src/AddReference.elm
+++ b/priv/lib-src/elm/src/AddReference.elm
@@ -64,9 +64,9 @@ view model =
     div [ class "row" ]
         [ div [ class "form-group col-xs-12" ]
             [ div []
-                [ label [ class "control-label" ] [ text "Bron toevoegen (optioneel)" ]
+                [ label [ class "control-label" ] [ text "Link naar bron toevoegen (optioneel)" ]
                 , p [ class "control-label-summary" ]
-                    [ text "Voeg hier de URL toe van bijvoorbeeld een video, artikel of website waar je bijdrage over gaat. Deze bron wordt onder je titel in het groene vlak geplaatst." ]
+                    [ text "Voeg hier de URL toe van bijvoorbeeld een video, artikel of website waar je bijdrage over gaat. Deze bron wordt onder je titel in het vlak geplaatst." ]
                 ]
             , p []
                 [ input

--- a/priv/templates/_aside_ginger_edit.contribution.tpl
+++ b/priv/templates/_aside_ginger_edit.contribution.tpl
@@ -8,5 +8,7 @@
         {% include "aside-connection/aside-add-connection.tpl" id=id cat="keyword" predicate="subject" title=_"Keywords" new_rsc_title=_"Keyword" dispatch="ginger_edit" helper_text_top=_"Add keywords so the knowledge can be found easily and relevant connections can be made." %}
 
         {% include "_ginger_edit_content_publication_date.tpl" %}
+
+        {% include "aside-connection/aside-add-connection.tpl" id=id cat="" predicate="hasreference" title="Achtergrondinformatie" %}
     {% endif %}
 </aside>

--- a/priv/templates/contribution/add-about.tpl
+++ b/priv/templates/contribution/add-about.tpl
@@ -6,7 +6,7 @@ as
     max
 %}
 
-    {% if id.about|is_undefined or id.about|length < 1 %}
+    {% if id.o.about|is_undefined or id.o.about|length < 1 %}
         <div id="elm-references"></div>
         {% javascript %}
             var referencesElement = document.getElementById("elm-references");

--- a/priv/templates/og/og-data.tpl
+++ b/priv/templates/og/og-data.tpl
@@ -1,5 +1,5 @@
 {# TODO ZOTONIC1: check this if/when the integration with bibliotheek.nl is fixed #}
-{% if id.og_title %}
+{% if id.og_title|default:id.title as title %}
 
 {% if nolink %}
     <div class="og-data">
@@ -17,13 +17,13 @@
         <small>{{ id.website|kc_domain_name_from_url }}</small>
 
         {% if nolink %}
-            <h3>{{ id.og_title|truncate:40 }}</h3>
+            <h3>{{ title|truncate:40 }}</h3>
         {% else %}
 
-            {% if id.og_title|match:".pdf" %}
-                <h3 class="break-word">{{ id.og_title }}</h3>
+            {% if title|match:".pdf" %}
+                <h3 class="break-word">{{ title }}</h3>
             {% else %}
-                <h3>{{ id.og_title }}</h3>
+                <h3>{{ title }}</h3>
             {% endif %}
 
             <p>{{ id.og_description|truncate:300 }}</p>

--- a/priv/translations/nl.po
+++ b/priv/translations/nl.po
@@ -716,7 +716,7 @@ msgstr "Markeer taak als voltooid"
 
 #: user/sites/kenniscloud/templates/_ginger_edit_content_publication_date.tpl:3
 msgid "Publication date"
-msgstr "Publicatie datum"
+msgstr "Publicatiedatum"
 
 #: user/sites/kenniscloud/templates/_ginger_edit_content_publication_date.tpl:4
 msgid "You can choose the date or type it directly into the text box."


### PR DESCRIPTION
Also alter copy to lessen confusion about links and references, and background information (they have overlapping terminology).
And fix a bug in the detection of an already present link (should be 1 max, but the condition remained true in any case because `about` itself was queried instead of the outgoing edges with predicate `about`).